### PR TITLE
Add support for db schema's

### DIFF
--- a/DatabaseScrambler/DatabaseScrambler.csproj
+++ b/DatabaseScrambler/DatabaseScrambler.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DatabaseScrambler</RootNamespace>
     <AssemblyName>DatabaseScrambler</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>

--- a/DatabaseScrambler/Domain/Configuration.cs
+++ b/DatabaseScrambler/Domain/Configuration.cs
@@ -19,7 +19,7 @@ namespace DatabaseScrambler.Domain
         [XmlAttribute("identifier")]
         public string Identifier { get; set; }
 
-        [XmlAttribute("value")] 
+        [XmlAttribute("value")]
         public string Value { get; set; }
     }
 }

--- a/DatabaseScrambler/Domain/Configuration.cs
+++ b/DatabaseScrambler/Domain/Configuration.cs
@@ -7,6 +7,9 @@ namespace DatabaseScrambler.Domain
         [XmlAttribute("type")]
         public ScrambleType Type { get; set; }
 
+        [XmlAttribute("schema")] 
+        public string Schema { get; set; } = "dbo";
+        
         [XmlAttribute("tableName")]
         public string TableName { get; set; }
 
@@ -16,7 +19,7 @@ namespace DatabaseScrambler.Domain
         [XmlAttribute("identifier")]
         public string Identifier { get; set; }
 
-        [XmlAttribute("value")]
+        [XmlAttribute("value")] 
         public string Value { get; set; }
     }
 }

--- a/DatabaseScrambler/Scramble/BaseScramble.cs
+++ b/DatabaseScrambler/Scramble/BaseScramble.cs
@@ -35,7 +35,7 @@ namespace DatabaseScrambler.Scramble
                                             , configuration.ColumnName  //1
                                             , ScrambleType              //2
                                             , configuration.Identifier  //3
-                                            , _random.Next(30000) //4
+                                            , _random.Next(30000)       //4
                                             , configuration.Schema);    //5
 
             using (var sqlCommand = new SqlCommand(sql, connection, transaction))

--- a/DatabaseScrambler/Scramble/BaseScramble.cs
+++ b/DatabaseScrambler/Scramble/BaseScramble.cs
@@ -35,7 +35,8 @@ namespace DatabaseScrambler.Scramble
                                             , configuration.ColumnName  //1
                                             , ScrambleType              //2
                                             , configuration.Identifier  //3
-                                            , _random.Next(30000));     //4
+                                            , _random.Next(30000) //4
+                                            , configuration.Schema);    //5
 
             using (var sqlCommand = new SqlCommand(sql, connection, transaction))
             {

--- a/DatabaseScrambler/Scramble/ScrambleClearColumn.cs
+++ b/DatabaseScrambler/Scramble/ScrambleClearColumn.cs
@@ -13,8 +13,8 @@ namespace DatabaseScrambler.Scramble
 
         public override void Scramble(SqlConnection connection, SqlTransaction transaction, Configuration configuration)
         {
-            const string sqlScript = "UPDATE [{0}] SET [{1}] = null";
-            var sql = string.Format(sqlScript, configuration.TableName, configuration.ColumnName);
+            const string sqlScript = "UPDATE [{0}].[{1}] SET [{2}] = null";
+            var sql = string.Format(sqlScript, configuration.Schema, configuration.TableName, configuration.ColumnName);
 
             using (var sqlCommand = new SqlCommand(sql, connection, transaction))
             {

--- a/DatabaseScrambler/Scramble/ScrambleClearTable.cs
+++ b/DatabaseScrambler/Scramble/ScrambleClearTable.cs
@@ -13,8 +13,8 @@ namespace DatabaseScrambler.Scramble
 
         public override void Scramble(SqlConnection connection, SqlTransaction transaction, Configuration configuration)
         {
-            const string sqlScript = "TRUNCATE TABLE [{0}]";
-            var sql = string.Format(sqlScript, configuration.TableName);
+            const string sqlScript = "TRUNCATE TABLE [{0}].[{1}]";
+            var sql = string.Format(sqlScript, configuration.Schema, configuration.TableName);
 
             using (var sqlCommand = new SqlCommand(sql, connection, transaction))
             {

--- a/DatabaseScrambler/Scramble/ScrambleSetContent.cs
+++ b/DatabaseScrambler/Scramble/ScrambleSetContent.cs
@@ -6,13 +6,14 @@ namespace DatabaseScrambler.Scramble
 {
     public class ScrambleSetContent : IScramble
     {
-        private string SetContentQuery = "UPDATE [{0}] SET [{1}] = {2};";
+        private string SetContentQuery = "UPDATE [{0}].[{1}] SET [{2}] = {3};";
 
         public void Scramble(SqlConnection connection, SqlTransaction transaction, Configuration configuration)
         {
-            var sql = string.Format(SetContentQuery, configuration.TableName  //0
-                                            , configuration.ColumnName      //1
-                                            , configuration.Value);         //2
+            var sql = string.Format(SetContentQuery, configuration.Schema, // 0
+                                            configuration.TableName               // 1
+                                            , configuration.ColumnName            // 2
+                                            , configuration.Value);               // 3
 
             try
             {

--- a/DatabaseScrambler/ScrambleConfiguration.xml
+++ b/DatabaseScrambler/ScrambleConfiguration.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <root>
-  <scramble type="FirstName" tableName="Person" columnName="FirstName" identifier="id" />
+  <scramble type="FirstName" schema="dbo" tableName="Person" columnName="FirstName" identifier="id" />
   <scramble type="LastName" tableName="Person" columnName="LastName" identifier="id" />
   <scramble type="Email" tableName="Person" columnName="Email" identifier="id" />
   <scramble type="NationalNumber" tableName="Person" columnName="NationalNumber" identifier="id" />

--- a/DatabaseScrambler/ScrambleCoordinator.cs
+++ b/DatabaseScrambler/ScrambleCoordinator.cs
@@ -50,7 +50,7 @@ namespace DatabaseScrambler
 
                         foreach (var configuration in GetConfiguration(configurationFile))
                         {
-                            Console.WriteLine($"Running scrambler {configuration.Type} for table '{configuration.TableName}', column '{configuration.ColumnName}'");
+                            Console.WriteLine($"Running scrambler {configuration.Type} for table '{configuration.Schema}.{configuration.TableName}', column '{configuration.ColumnName}'");
 
                             var scrambleAction = _scrambleActions.SingleOrDefault(x => x.CanScramble(configuration.Type));
                             if (scrambleAction == null)

--- a/DatabaseScrambler/Scripts/SingleColumnSramble.sql
+++ b/DatabaseScrambler/Scripts/SingleColumnSramble.sql
@@ -3,6 +3,7 @@
 --{2} = scramble type
 --{3} = Identifier
 --{4} = Seed
+--{5} = Schema
 
 
 DECLARE @numberOfValues int;
@@ -12,16 +13,16 @@ SET @numberOfValues = (select count(1) from #ScrambleData where type = '{2}');
 --We assume the table is an entity table and has an id column
 with TableWithRandomNumber as (
 	select 
-		top( select count(1) from [{0}] ) 
-			[{0}].*, 
+		top( select count(1) from [{5}].[{0}] ) 
+			[{5}].[{0}].*, 
 			([{3}] + {4}) % @numberOfValues RandomNumber
-	from [{0}]
+	from [{5}].[{0}]
 	order by  RandomNumber
 )
 
-update [{0}]
+update [{5}].[{0}]
 set [{1}] = #ScrambleData.value
 from TableWithRandomNumber
-inner join [{0}] on [{0}].[{3}] = TableWithRandomNumber.[{3}]
+inner join [{5}].[{0}] on [{5}].[{0}].[{3}] = TableWithRandomNumber.[{3}]
 inner join #ScrambleData on #ScrambleData.ValueIndex = TableWithRandomNumber.RandomNumber
-where [{0}].[{1}] is not null and #ScrambleData.type = '{2}'
+where [{5}].[{0}].[{1}] is not null and #ScrambleData.type = '{2}'


### PR DESCRIPTION
Add's the schema option if there is no value selected it fails back to the [dbo] schema.

Possible problems:
- Not all databases supports schemas
- The default user schema can be different then dbo